### PR TITLE
Fixes to accommodate changes to 1.0.0 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,8 @@ if(COMMAND cmake_policy)
 	cmake_policy(SET CMP0015 OLD)  
 endif(COMMAND cmake_policy)
 
+set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
+
 SET(EXECUTABLE_OUTPUT_PATH ".")
 
 if(MSVC12)
@@ -58,6 +60,7 @@ SET(SDL_LIBRARIES SDL2 SDL2main)
 find_package(CUDA 6.5 REQUIRED)
 find_package(OpenGL 3.0 REQUIRED)
 find_package(OpenCV 2.4 COMPONENTS core highgui imgproc REQUIRED)
+find_package(Eigen3 REQUIRED)
 
 include_directories(${ZED_INCLUDE_DIRS})
 include_directories(${GLUT_INCLUDE_DIRS})
@@ -67,6 +70,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 include_directories(${OCULUS_INCLUDE_DIRS})
 include_directories(${SDL_INCLUDE_DIRS})
 include_directories(${CUDA_INCLUDE_DIRS})
+include_directories(${EIGEN3_INCLUDE_DIR})
 
 
 link_directories(${ZED_LIBRARY_DIR})

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ _Note: This sample works with Oculus DK2 and CV1._
 It demonstrates how to grab stereo images with the ZED SDK and display the results in a Oculus Rift headset.
 
 **Prerequisites**
- - ZED SDK 0.9.2 or later
+ - ZED SDK 1.0.0 or later
  - [Oculus PC Runtime 1.3.0](https://www.oculus.com/en-us/setup/) (This URL may change in near future)
  - [Oculus PC SDK 1.3.0](https://developer.oculus.com/downloads/pc/1.3.0/Oculus_SDK_for_Windows/) 
  - OpenGL 3+

--- a/cmake/FindEigen3.cmake
+++ b/cmake/FindEigen3.cmake
@@ -1,0 +1,81 @@
+# - Try to find Eigen3 lib
+#
+# This module supports requiring a minimum version, e.g. you can do
+#   find_package(Eigen3 3.1.2)
+# to require version 3.1.2 or newer of Eigen3.
+#
+# Once done this will define
+#
+#  EIGEN3_FOUND - system has eigen lib with correct version
+#  EIGEN3_INCLUDE_DIR - the eigen include directory
+#  EIGEN3_VERSION - eigen version
+
+# Copyright (c) 2006, 2007 Montel Laurent, <montel@kde.org>
+# Copyright (c) 2008, 2009 Gael Guennebaud, <g.gael@free.fr>
+# Copyright (c) 2009 Benoit Jacob <jacob.benoit.1@gmail.com>
+# Redistribution and use is allowed according to the terms of the 2-clause BSD license.
+
+if(NOT Eigen3_FIND_VERSION)
+  if(NOT Eigen3_FIND_VERSION_MAJOR)
+    set(Eigen3_FIND_VERSION_MAJOR 2)
+  endif(NOT Eigen3_FIND_VERSION_MAJOR)
+  if(NOT Eigen3_FIND_VERSION_MINOR)
+    set(Eigen3_FIND_VERSION_MINOR 91)
+  endif(NOT Eigen3_FIND_VERSION_MINOR)
+  if(NOT Eigen3_FIND_VERSION_PATCH)
+    set(Eigen3_FIND_VERSION_PATCH 0)
+  endif(NOT Eigen3_FIND_VERSION_PATCH)
+
+  set(Eigen3_FIND_VERSION "${Eigen3_FIND_VERSION_MAJOR}.${Eigen3_FIND_VERSION_MINOR}.${Eigen3_FIND_VERSION_PATCH}")
+endif(NOT Eigen3_FIND_VERSION)
+
+macro(_eigen3_check_version)
+  file(READ "${EIGEN3_INCLUDE_DIR}/Eigen/src/Core/util/Macros.h" _eigen3_version_header)
+
+  string(REGEX MATCH "define[ \t]+EIGEN_WORLD_VERSION[ \t]+([0-9]+)" _eigen3_world_version_match "${_eigen3_version_header}")
+  set(EIGEN3_WORLD_VERSION "${CMAKE_MATCH_1}")
+  string(REGEX MATCH "define[ \t]+EIGEN_MAJOR_VERSION[ \t]+([0-9]+)" _eigen3_major_version_match "${_eigen3_version_header}")
+  set(EIGEN3_MAJOR_VERSION "${CMAKE_MATCH_1}")
+  string(REGEX MATCH "define[ \t]+EIGEN_MINOR_VERSION[ \t]+([0-9]+)" _eigen3_minor_version_match "${_eigen3_version_header}")
+  set(EIGEN3_MINOR_VERSION "${CMAKE_MATCH_1}")
+
+  set(EIGEN3_VERSION ${EIGEN3_WORLD_VERSION}.${EIGEN3_MAJOR_VERSION}.${EIGEN3_MINOR_VERSION})
+  if(${EIGEN3_VERSION} VERSION_LESS ${Eigen3_FIND_VERSION})
+    set(EIGEN3_VERSION_OK FALSE)
+  else(${EIGEN3_VERSION} VERSION_LESS ${Eigen3_FIND_VERSION})
+    set(EIGEN3_VERSION_OK TRUE)
+  endif(${EIGEN3_VERSION} VERSION_LESS ${Eigen3_FIND_VERSION})
+
+  if(NOT EIGEN3_VERSION_OK)
+
+    message(STATUS "Eigen3 version ${EIGEN3_VERSION} found in ${EIGEN3_INCLUDE_DIR}, "
+                   "but at least version ${Eigen3_FIND_VERSION} is required")
+  endif(NOT EIGEN3_VERSION_OK)
+endmacro(_eigen3_check_version)
+
+if (EIGEN3_INCLUDE_DIR)
+
+  # in cache already
+  _eigen3_check_version()
+  set(EIGEN3_FOUND ${EIGEN3_VERSION_OK})
+
+else (EIGEN3_INCLUDE_DIR)
+
+  find_path(EIGEN3_INCLUDE_DIR NAMES signature_of_eigen3_matrix_library
+      PATHS
+      ${CMAKE_INSTALL_PREFIX}/include
+      ${KDE4_INCLUDE_DIR}
+      PATH_SUFFIXES eigen3 eigen
+    )
+
+  if(EIGEN3_INCLUDE_DIR)
+    _eigen3_check_version()
+  endif(EIGEN3_INCLUDE_DIR)
+
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(Eigen3 DEFAULT_MSG EIGEN3_INCLUDE_DIR EIGEN3_VERSION_OK)
+
+  mark_as_advanced(EIGEN3_INCLUDE_DIR)
+
+endif(EIGEN3_INCLUDE_DIR)
+

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -133,7 +133,8 @@ int main(int argc, char **argv)
 	// Initialize the ZED Camera
 	sl::zed::Camera* zed = 0;
 	zed = new sl::zed::Camera(sl::zed::HD720);
-	sl::zed::ERRCODE zederr = zed->init(sl::zed::MODE::PERFORMANCE, 0);
+	sl::zed::InitParams* init_parameters = new sl::zed::InitParams(sl::zed::MODE::PERFORMANCE);
+	sl::zed::ERRCODE zederr = zed->init(*init_parameters);
 	int zedWidth = zed->getImageSize().width;
 	int zedHeight = zed->getImageSize().height;
 	if (zederr != sl::zed::SUCCESS)
@@ -465,7 +466,7 @@ int main(int argc, char **argv)
 		if (isVisible)
 		{
 			// If successful grab a new ZED image
-			if (!zed->grab(sl::zed::SENSING_MODE::RAW, false, false))
+			if (!zed->grab(sl::zed::SENSING_MODE::STANDARD, false, false))
 			{
 				// Update the ZED frame counter
 				zedc++;


### PR DESCRIPTION
Simple fixes to accommodate changes from 0.9.2 to 1.0.0, namely:
- The use of InitParams to initialise Camera
- The change of SENSING_MODE enumeration (RAW becomes STANDARD)
- CMakeLists now includes Eigen includes, through cmake\FindEigen3.cmake.

Tested to work on Oculus CV1 using ZED SDK 1.1.0, CMake 3.3, and Visual Studio 2013.
